### PR TITLE
Fix random crash in Rampage World Tour

### DIFF
--- a/src/vidhrdw/midtunit_vidhrdw.c
+++ b/src/vidhrdw/midtunit_vidhrdw.c
@@ -644,7 +644,12 @@ static void dma_callback(int is_in_34010_context)
 
 READ16_HANDLER( midtunit_dma_r )
 {
-	return dma_register[offset];
+	/* rmpgwt sometimes reads register 0, expecting it to return the */
+	/* current DMA status; thus we map register 0 to register 1 */
+	/* openice does it as well */
+	if (offset == 0)
+		offset = 1;
+ 	return dma_register[offset];
 }
 
 


### PR DESCRIPTION
This fix from MAME114 will stop the game randomly crashing at the end of a level