### PR TITLE
Fix compilation error on MacOS

### DIFF
--- a/src/usrintrf.c
+++ b/src/usrintrf.c
@@ -13,6 +13,7 @@
 #include <retro_inline.h>
 
 #include "driver.h"
+#include "artwork.h"
 #include "info.h"
 #include "datafile.h"
 #include "ui_text.h"


### PR DESCRIPTION
Fixes the following compile errors:
```
src/usrintrf.c:240:2: error: implicit declaration of function 'artwork_mark_ui_dirty' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        artwork_mark_ui_dirty(rect->min_x, rect->min_y, rect->max_x, rect->max_y);
        ^
src/usrintrf.c:256:2: error: implicit declaration of function 'artwork_get_screensize' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        artwork_get_screensize(&w, &h);
        ^
src/usrintrf.c:294:2: error: implicit declaration of function 'artwork_get_screensize' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        artwork_get_screensize(&w, &h);
```