### PR TITLE
Remove outdated Wii U compiler flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,8 @@ else ifeq ($(platform), wiiu)
     
    CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
    AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
-   PLATCFLAGS += -DGEKKO -DWIIU -mwup -mcpu=750 -meabi -mhard-float -D__ppc__ -D__POWERPC__ -Dstricmp=strcasecmp
+   PLATCFLAGS += -DGEKKO -DWIIU -D__wiiu__ -DHW_WUP -ffunction-sections -fdata-sections
+   PLATCFLAGS += -mcpu=750 -meabi -mhard-float -D__ppc__ -D__POWERPC__ -Dstricmp=strcasecmp
    PLATCFLAGS += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
    STATIC_LINKING = 1
 


### PR DESCRIPTION
Proactive buildfix per https://github.com/libretro/RetroArch/pull/14925, which will necessitate an update of the Wii U toolchain to a version which no longer supports the `-mwup` flag. Safe to merge now; new flags are synonymous and function in both old and new toolchains.