### PR TITLE
ci: add a Linux aarch64 build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,6 +21,10 @@ include:
   # Linux 64-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-x64.yml'
+
+  # Linux ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-aarch64.yml'
     
   ################################## CELLULAR ################################
   # Android
@@ -58,6 +62,12 @@ libretro-build-windows-x64:
 libretro-build-linux-x64:
   extends:
     - .libretro-linux-x64-make-default
+    - .core-defs
+
+# Linux ARM 64-bit
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-aarch64-make-default
     - .core-defs
      
 ################################### CELLULAR #################################


### PR DESCRIPTION
The libretro buildbot ships no aarch64 Linux build of MAME 2003 Midway, so the core can't be installed from RetroArch's Core Downloader on ARM64 Linux machines (ARM Chromebooks, SBCs, ARM laptops). Nothing blocks it: the `unix` branch of the Makefile is arch-neutral, there is no x86 assembly in the build, and `android-arm64-v8a` already builds these sources for ARM64.

The job mirrors `libretro-build-linux-x64`:

```yaml
# Linux ARM 64-bit
libretro-build-linux-aarch64:
  extends:
    - .libretro-linux-aarch64-make-default
    - .core-defs
```

plus the matching `/linux-aarch64.yml` template include.

Verified natively on aarch64 (postmarketOS, glibc, GCC 15): `make platform=unix` builds clean with no source changes, producing `mame2003_midway_libretro.so` (ELF 64-bit ARM aarch64), and the core loads and initialises in a libretro host. I didn't run a game on it - I have no Midway arcade ROM set here - so this is a build/load verification only.
